### PR TITLE
Load multiple locations for namespace

### DIFF
--- a/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
+++ b/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
@@ -58,6 +58,6 @@ class FileSymbolLoaderTest extends AbstractIntegrationTestCase
          * TODO find a better strategy for testing this scenario
          */
         $this->expectNotToPerformAssertions();
-        $this->loadConsumedFileSymbols(self::ARRAY_NAMESPACE, [AutoloadType::PSR4]);
+        $this->loadConsumedFileSymbols(self::ARRAY_NAMESPACE, [AutoloadType::FILES]);
     }
 }

--- a/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
+++ b/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
@@ -11,6 +11,7 @@ class FileSymbolLoaderTest extends AbstractIntegrationTestCase
 {
     private const ONLY_FILE_DEPS = __DIR__ . '/../../../assets/TestProjects/OnlyFileDependencies';
     private const AUTOLOAD_FILES_REQUIRE = __DIR__ . '/../../../assets/TestProjects/AutoloadFilesWithRequire';
+    private const ARRAY_NAMESPACE = __DIR__ . '/../../../assets/TestProjects/ArrayNamespace';
 
     /**
      * @test
@@ -46,5 +47,17 @@ class FileSymbolLoaderTest extends AbstractIntegrationTestCase
         self::assertCount(2, $symbols);
         self::assertArrayHasKey('Ds\Vector', $symbols);
         self::assertArrayHasKey('json_encode', $symbols);
+    }
+
+    /**
+     * @test
+     */
+    public function itFindsArraySymbols(): void
+    {
+        /**
+         * TODO find a better strategy for testing this scenario
+         */
+        $this->expectNotToPerformAssertions();
+        $this->loadConsumedFileSymbols(self::ARRAY_NAMESPACE, [AutoloadType::PSR4]);
     }
 }

--- a/tests/Stubs/TestPackage.php
+++ b/tests/Stubs/TestPackage.php
@@ -10,7 +10,7 @@ use ComposerUnused\Contracts\PackageInterface;
 
 final class TestPackage implements PackageInterface
 {
-    /** @phpstan-var array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} */
+    /** @var array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>} */
     public array $autoload = [];
     public string $name = '';
     /** @var array<LinkInterface> */

--- a/tests/assets/TestProjects/ArrayNamespace/composer.json
+++ b/tests/assets/TestProjects/ArrayNamespace/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "multi/paths",
+  "require": {
+  },
+  "autoload": {
+    "psr-4": {
+      "EmptyRequire\\": ["src/", "web/"],
+      "Configuration\\": "config/"
+    }
+  }
+}

--- a/tests/assets/TestProjects/ArrayNamespace/config/container.php
+++ b/tests/assets/TestProjects/ArrayNamespace/config/container.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Configuration;
+
+echo "Hello";

--- a/tests/assets/TestProjects/ArrayNamespace/src/TestClass.php
+++ b/tests/assets/TestProjects/ArrayNamespace/src/TestClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmptyRequire;
+
+class TestClass
+{
+    public function testMethod(): void
+    {
+    }
+}

--- a/tests/assets/TestProjects/ArrayNamespace/web/index.php
+++ b/tests/assets/TestProjects/ArrayNamespace/web/index.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmptyRequire;
+
+echo "Hello";


### PR DESCRIPTION
This PR fixes a bug reported in https://github.com/composer-unused/composer-unused/issues/293 regarding the inability to load multiple paths for a single PSR-0/PSR-4 namespace.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?