### PR TITLE
Add FullQualifiedParameterStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed issue where `UseStrategy`, `ExtendsParseStrategy` and `ImplementsParseStrategy` resulted in partial symbol names
 ### Added
 - Added `TypedAttributeStrategy` to recognize usage for consumed full qualified property types
+- Added `FullQualifiedParameterStrategy` to recognize usage for consumed full qualified parameter types
 ### Changed
 ### Removed
 

--- a/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
+++ b/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
+
+final class FullQualifiedParameterStrategy implements StrategyInterface
+{
+    public function canHandle(Node $node): bool
+    {
+        if (!$node instanceof Node\Stmt\ClassMethod) {
+            return false;
+        }
+
+        return count($node->params) > 0;
+    }
+
+    /**
+     * @param Node&Node\Stmt\ClassMethod $node
+     * @return array<string>
+     */
+    public function extractSymbolNames(Node $node): array
+    {
+        /** @var array<Node\Param> $params */
+        $params = $node->params;
+
+        $typedParams = array_filter($params, static function (Node\Param $param) {
+            return $param->type instanceof FullyQualified;
+        });
+
+        return array_map(static function (Node\Param $param) {
+            /** @var FullyQualified $type */
+            $type = $param->type;
+            return $type->toString();
+        }, $typedParams);
+    }
+}


### PR DESCRIPTION
Using this strategy, the collector will recognize consumed symbols by FQN parameter types.
