### PR TITLE
Fix composer.json constraint for symfony/finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "nikic/php-parser": "^4.13",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2 || ^3",
-        "symfony/finder": "4.4 || ^5.3 || ^6.0"
+        "symfony/finder": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
         "ext-ds": "*",


### PR DESCRIPTION
This was wrecking my brains, up until I noticed that the constraint was totally wrong...

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)? No, I did not test it manually
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?
