### PR TITLE
Return empty symbol list when reflection could not be loaded

### DIFF
--- a/src/Symbol/Loader/ExtensionSymbolLoader.php
+++ b/src/Symbol/Loader/ExtensionSymbolLoader.php
@@ -7,6 +7,7 @@ namespace ComposerUnused\SymbolParser\Symbol\Loader;
 use ComposerUnused\Contracts\PackageInterface;
 use Generator;
 use ComposerUnused\SymbolParser\Symbol\Symbol;
+use ReflectionException;
 use ReflectionExtension;
 
 final class ExtensionSymbolLoader implements SymbolLoaderInterface
@@ -25,9 +26,13 @@ final class ExtensionSymbolLoader implements SymbolLoaderInterface
 
         $packageName = str_replace('ext-', '', $package->getName());
 
-        $reflection = new ReflectionExtension(
-            self::EXTENSION_ALIAS[$packageName] ?? $packageName
-        );
+        try {
+            $reflection = new ReflectionExtension(
+                self::EXTENSION_ALIAS[$packageName] ?? $packageName
+            );
+        } catch (ReflectionException $e) {
+            return [];
+        }
 
         $symbolNames = array_merge(
             array_flip($reflection->getClassNames()),


### PR DESCRIPTION
When an extension can't be loaded, we provide an empty list of symbols.
This way the "extension" is unused and can therefor be ignored using composer-unused settings.

Closes https://github.com/composer-unused/composer-unused/issues/373