### PR TITLE
Fix: Match short namespace symbols

### DIFF
--- a/src/Symbol/NamespaceSymbol.php
+++ b/src/Symbol/NamespaceSymbol.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ComposerUnused\SymbolParser\Symbol;
 
+use function rtrim;
+
 final class NamespaceSymbol implements SymbolInterface
 {
     /** @var string */
@@ -11,7 +13,7 @@ final class NamespaceSymbol implements SymbolInterface
 
     public function __construct(string $namespace)
     {
-        $this->namespace = $namespace;
+        $this->namespace = rtrim($namespace, '\\') . '\\';
     }
 
     public static function fromClass(string $class): self
@@ -26,6 +28,6 @@ final class NamespaceSymbol implements SymbolInterface
 
     public function matches(SymbolInterface $symbol): bool
     {
-        return strpos($symbol->getIdentifier(), $this->namespace) === 0;
+        return strpos(rtrim($symbol->getIdentifier(), '\\') . '\\', $this->namespace) === 0;
     }
 }

--- a/tests/Unit/Symbol/NamespaceSymbolTest.php
+++ b/tests/Unit/Symbol/NamespaceSymbolTest.php
@@ -32,4 +32,15 @@ class NamespaceSymbolTest extends TestCase
 
         self::assertTrue($namespaceSymbol->matches($namespaceSymbolFromClass));
     }
+
+    /**
+     * @test
+     */
+    public function itShouldMatchShortNamespaces(): void
+    {
+        $namespaceSymbol = new NamespaceSymbol('Foo\\Baz\\');
+        $symbol = new Symbol('Foo\\Baz');
+
+        self::assertTrue($namespaceSymbol->matches($symbol));
+    }
 }


### PR DESCRIPTION
### Problem

When using short namespaces instead of full namespaces, the symbol should properly match in order to detect usages of a required package.

### Example

A package with PSR-4 namespace `Cocur\Slugify\` is required. The project code base contains the following class:

```php
<?php

use Cocur\Slugify;

final class MyBeautifulClass
{
    public function __construct(
        private readonly Slugify\Slugify $slugify,
    ) {
    }
}
```

In this example, the namespace symbol would not match, because the registered PSR-4 namespace contains a trailing backslash whereas the imported namespace in the class does not.

### Solution

To resolve incorrect behavior in such cases, a trailing backslash is now always appended to the constructed namespace symbols.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
