### PR TITLE
Feature: Handle name resolving with PHP-Parser's NameResolver

### DIFF
--- a/src/Parser/PHP/SymbolNameParser.php
+++ b/src/Parser/PHP/SymbolNameParser.php
@@ -10,6 +10,7 @@ use ComposerUnused\SymbolParser\Symbol\Provider\FileIterationInterface;
 use Generator;
 use PhpParser\Error;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use SplFileInfo;
 
@@ -21,10 +22,11 @@ final class SymbolNameParser implements SymbolNameParserInterface
     private ?FileIterationInterface $fileIterator = null;
     private ?SplFileInfo $currentFile = null;
 
-    public function __construct(Parser $parser, SymbolCollectorInterface $visitor)
+    public function __construct(Parser $parser, NameResolver $nameResolver, SymbolCollectorInterface $visitor)
     {
         $this->parser = $parser;
         $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($nameResolver);
         $this->traverser->addVisitor($visitor);
 
         $this->visitor = $visitor;

--- a/src/Symbol/NamespaceSymbol.php
+++ b/src/Symbol/NamespaceSymbol.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ComposerUnused\SymbolParser\Symbol;
 
-use function rtrim;
-
 final class NamespaceSymbol implements SymbolInterface
 {
     /** @var string */
@@ -13,7 +11,7 @@ final class NamespaceSymbol implements SymbolInterface
 
     public function __construct(string $namespace)
     {
-        $this->namespace = rtrim($namespace, '\\') . '\\';
+        $this->namespace = $namespace;
     }
 
     public static function fromClass(string $class): self
@@ -28,6 +26,6 @@ final class NamespaceSymbol implements SymbolInterface
 
     public function matches(SymbolInterface $symbol): bool
     {
-        return strpos(rtrim($symbol->getIdentifier(), '\\') . '\\', $this->namespace) === 0;
+        return strpos($symbol->getIdentifier(), $this->namespace) === 0;
     }
 }

--- a/tests/Integration/AbstractIntegrationTestCase.php
+++ b/tests/Integration/AbstractIntegrationTestCase.php
@@ -23,6 +23,7 @@ use ComposerUnused\SymbolParser\Symbol\SymbolInterface;
 use ComposerUnused\SymbolParser\Test\Stubs\Config;
 use ComposerUnused\SymbolParser\Test\Stubs\TestLink;
 use ComposerUnused\SymbolParser\Test\Stubs\TestPackage;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -67,6 +68,7 @@ class AbstractIntegrationTestCase extends TestCase
             new FileSymbolProvider(
                 new SymbolNameParser(
                     (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+                    new NameResolver(),
                     new DefinedSymbolCollector()
                 ),
                 new FileContentProvider()
@@ -96,6 +98,7 @@ class AbstractIntegrationTestCase extends TestCase
             new FileSymbolProvider(
                 new SymbolNameParser(
                     (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+                    new NameResolver(),
                     new ConsumedSymbolCollector(
                         [
                             new NewStrategy(),

--- a/tests/Integration/Parser/PHP/SymbolNameParserTest.php
+++ b/tests/Integration/Parser/PHP/SymbolNameParserTest.php
@@ -8,6 +8,7 @@ use ComposerUnused\SymbolParser\Parser\PHP\ConsumedSymbolCollector;
 use ComposerUnused\SymbolParser\Parser\PHP\DefinedSymbolCollector;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\ConstStrategy;
 use ComposerUnused\SymbolParser\Parser\PHP\SymbolNameParser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 
@@ -49,6 +51,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 
@@ -76,6 +79,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 
@@ -101,6 +105,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 
@@ -127,6 +132,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 
@@ -150,6 +156,7 @@ class SymbolNameParserTest extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new ConsumedSymbolCollector([new ConstStrategy()])
         );
 

--- a/tests/ParserTestCase.php
+++ b/tests/ParserTestCase.php
@@ -8,6 +8,7 @@ use ComposerUnused\SymbolParser\Parser\PHP\ConsumedSymbolCollector;
 use ComposerUnused\SymbolParser\Parser\PHP\DefinedSymbolCollector;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\StrategyInterface;
 use ComposerUnused\SymbolParser\Parser\PHP\SymbolNameParser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +22,7 @@ class ParserTestCase extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new ConsumedSymbolCollector($strategies)
         );
 
@@ -34,6 +36,7 @@ class ParserTestCase extends TestCase
     {
         $symbolNameParser = new SymbolNameParser(
             (new ParserFactory())->create(ParserFactory::ONLY_PHP7),
+            new NameResolver(),
             new DefinedSymbolCollector()
         );
 

--- a/tests/Unit/Parser/PHP/Strategy/TypedAttributeStrategyTest.php
+++ b/tests/Unit/Parser/PHP/Strategy/TypedAttributeStrategyTest.php
@@ -37,7 +37,8 @@ final class TypedAttributeStrategyTest extends ParserTestCase
 
         $symbols = $this->parseConsumedSymbols([$this->stragety], $code);
 
-        self::assertCount(1, $symbols);
-        self::assertSame('My\Namespace\Bar', $symbols[0]);
+        self::assertCount(2, $symbols);
+        self::assertSame('Other\Fubar', $symbols[0]);
+        self::assertSame('My\Namespace\Bar', $symbols[1]);
     }
 }

--- a/tests/Unit/Parser/PHP/SymbolNameParserTest.php
+++ b/tests/Unit/Parser/PHP/SymbolNameParserTest.php
@@ -75,9 +75,10 @@ final class SymbolNameParserTest extends ParserTestCase
             $code
         );
 
-        self::assertCount(3, $symbols);
-        self::assertSame('My\NameSpace1\Bar', $symbols[0]);
+        self::assertCount(4, $symbols);
+        self::assertSame('My\NameSpace1', $symbols[0]);
         self::assertSame('B\NS\MyClass', $symbols[1]);
-        self::assertSame('Other\Namespace2\Baz', $symbols[2]);
+        self::assertSame('My\NameSpace1\Bar', $symbols[2]);
+        self::assertSame('Other\Namespace2\Baz', $symbols[3]);
     }
 }

--- a/tests/Unit/Symbol/NamespaceSymbolTest.php
+++ b/tests/Unit/Symbol/NamespaceSymbolTest.php
@@ -32,15 +32,4 @@ class NamespaceSymbolTest extends TestCase
 
         self::assertTrue($namespaceSymbol->matches($namespaceSymbolFromClass));
     }
-
-    /**
-     * @test
-     */
-    public function itShouldMatchShortNamespaces(): void
-    {
-        $namespaceSymbol = new NamespaceSymbol('Foo\\Baz\\');
-        $symbol = new Symbol('Foo\\Baz');
-
-        self::assertTrue($namespaceSymbol->matches($symbol));
-    }
 }


### PR DESCRIPTION
Hi @icanhazstring, sorry for the noise, but I've probably found a better solution than the one introduced with #91. Please let me know what you think about it :)

💡 The current implementation would also require a change in `composer-unused` since the constructor signature of `SymbolNameParser` has changed. I can take care of that as well in case you accept the changes in this PR :)

### Suggested change

Name resolving of namespace-scoped symbols (such as classes, functions and constants) is now done through PHP-Parser's [NameResolver](https://github.com/nikic/PHP-Parser/blob/4.x/doc/component/Name_resolution.markdown). By using it as an additional node visitor, we add a safe additional layer on top of the collection strategies provided by the symbol-parser package. Usage of the NameResolver resolves the exact same issue I outlined in #91.

⚠️ This also makes the fix introduced with 13fd5e9595a7c9930888e3a5a1fe3b8a9e8824e0 obsolete
now, as the `NameResolver` is more accurate. I reverted the change as part of this PR (see 0a2d5ab4e11957601af29e1e4514fb1d8eee367a).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
