### PR TITLE
Add failing test for undesired namespace consolidation

### DIFF
--- a/tests/Unit/Parser/PHP/SymbolNameParserTest.php
+++ b/tests/Unit/Parser/PHP/SymbolNameParserTest.php
@@ -81,4 +81,24 @@ final class SymbolNameParserTest extends ParserTestCase
         self::assertSame('My\NameSpace1\Bar', $symbols[2]);
         self::assertSame('Other\Namespace2\Baz', $symbols[3]);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldNotConsolidateDifferentNamespaces(): void
+    {
+        $code = <<<CODE
+        <?php
+
+        use My\Space\Using\ForeignUtility;
+        use ForeignUtility\SpecialClass;
+
+        CODE;
+
+        $symbols = $this->parseConsumedSymbols([new UseStrategy()], $code);
+
+        self::assertCount(2, $symbols);
+        self::assertSame('My\Space\Using\ForeignUtility', $symbols[0]);
+        self::assertSame('ForeignUtility\SpecialClass', $symbols[1]);
+    }
 }


### PR DESCRIPTION
If you have two namespaces that have common parts, they are treated like partial imports and are combined into one.
I only added a failing test case to demonstrate the problem. Please feel free to add your commits to this PR to fix the underlying issue.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?