### PR TITLE
Bump nikic/php-parser to 4.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "composer-unused/contracts": "^0.3",
-        "nikic/php-parser": "^4.15",
+        "nikic/php-parser": "^4.16",
         "phpstan/phpdoc-parser": "^1.22",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2 || ^3",

--- a/src/Parser/PHP/DefinedSymbolCollector.php
+++ b/src/Parser/PHP/DefinedSymbolCollector.php
@@ -62,7 +62,7 @@ final class DefinedSymbolCollector extends AbstractCollector
         if ($node instanceof Node\Stmt\Expression && $node->expr instanceof Node\Expr\FuncCall) {
             /** @var Node\Name $expressionName */
             $expressionName = $node->expr->name;
-            $functionName = $expressionName->parts[0] ?? null;
+            $functionName = $expressionName->getParts()[0] ?? null;
             $firstArgument = $node->expr->args[0];
             assert($firstArgument instanceof Node\Arg);
 

--- a/src/Parser/PHP/Strategy/ConstStrategy.php
+++ b/src/Parser/PHP/Strategy/ConstStrategy.php
@@ -18,6 +18,6 @@ final class ConstStrategy implements StrategyInterface
      */
     public function extractSymbolNames(Node $node): array
     {
-        return [$node->name->parts[0]];
+        return [$node->name->getParts()[0]];
     }
 }

--- a/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
+++ b/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
@@ -104,19 +104,19 @@ final class PhpExtensionStrategy implements StrategyInterface
     private function getNameFromNode(Node $node): string
     {
         if ($node instanceof Node\Name\FullyQualified) {
-            return implode('\\', $node->parts);
+            return implode('\\', $node->getParts());
         }
 
         if ($node instanceof Node\Stmt\UseUse) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         if ($node instanceof Node\Expr\ConstFetch) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         return '';

--- a/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
+++ b/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
@@ -86,19 +86,19 @@ final class UsedExtensionSymbolStrategy implements StrategyInterface
     private function getNameFromNode(Node $node): string
     {
         if ($node instanceof Node\Name\FullyQualified) {
-            return implode('\\', $node->parts);
+            return implode('\\', $node->getParts());
         }
 
         if ($node instanceof Node\Stmt\UseUse) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         if ($node instanceof Node\Expr\ConstFetch) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            return $node->name->parts[0];
+            return $node->name->getParts()[0];
         }
 
         return '';


### PR DESCRIPTION
php-parser 4.16.0 releaesed with deprecating `Name::$parts`, this PR update it to use `getParts()`  instead.

https://github.com/nikic/PHP-Parser/releases/tag/v4.16.0

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
