### PR TITLE
Add symfony 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpstan/phpdoc-parser": "^1.23",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2 || ^3",
-        "symfony/finder": "^4.4 || ^5.3 || ^6.0"
+        "symfony/finder": "^4.4 || ^5.3 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-ds": "*",


### PR DESCRIPTION
Hi @icanhazstring, seems like a release with SF7 support is also need in order to allows installing SF7 on https://github.com/composer-unused/composer-unused