### PR TITLE
Clean-up unusedcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cs-check.json
 .phpunit.result.cache
 /build/
 *.phar
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        'no_unused_imports' => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('vendor')
+            ->notPath('assets/TestFiles/UseSingleLineNoGroup.php')
+            ->in([__DIR__.'/src/', __DIR__.'/tests/'])
+    )
+;

--- a/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
+++ b/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
 
 final class FullQualifiedParameterStrategy implements StrategyInterface

--- a/src/Parser/PHP/SymbolCollectorInterface.php
+++ b/src/Parser/PHP/SymbolCollectorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ComposerUnused\SymbolParser\Parser\PHP;
 
 use Closure;
-use ComposerUnused\SymbolParser\Symbol\SymbolName;
 use PhpParser\NodeVisitor;
 
 interface SymbolCollectorInterface extends NodeVisitor

--- a/src/Symbol/Loader/FileSymbolLoader.php
+++ b/src/Symbol/Loader/FileSymbolLoader.php
@@ -50,7 +50,7 @@ final class FileSymbolLoader implements SymbolLoaderInterface
             array_merge(...$paths)
         );
 
-        $sourceFolders = array_filter($sourceFolders, [$this, 'filterExistingDir']);
+        $sourceFolders = array_filter($sourceFolders, fn (string $dir): bool => $this->filterExistingDir($dir));
 
         $finder = new Finder();
 

--- a/src/Symbol/Loader/PsrSymbolLoader.php
+++ b/src/Symbol/Loader/PsrSymbolLoader.php
@@ -8,6 +8,7 @@ use ComposerUnused\Contracts\PackageInterface;
 use Generator;
 use ComposerUnused\SymbolParser\Symbol\NamespaceSymbol;
 
+use function array_keys;
 use function array_merge;
 
 final class PsrSymbolLoader implements SymbolLoaderInterface
@@ -19,7 +20,7 @@ final class PsrSymbolLoader implements SymbolLoaderInterface
             $package->getAutoload()['psr-0'] ?? []
         );
 
-        foreach ($namespaces as $namespace => $dir) {
+        foreach (array_keys($namespaces) as $namespace) {
             yield new NamespaceSymbol($namespace);
         }
     }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Goal 1

By running PHP Mess Detector on this repository, I've recently opened a [report](https://github.com/phpmd/phpmd/issues/1066) about unused private method.

Here are original reporting with PHPMD 2.15 (PHAR version)

```shell
php -d error_reporting=8191 phpmd.phar src ansi unusedcode
```

Expected results :

```text
Found 0 violations and 0 errors in 359ms

No mess detected
```

Current results : 

```text
FILE: /shared/backups/forks/symbol-parser/src/Symbol/Loader/FileSymbolLoader.php
--------------------------------------------------------------------------------
 139 | VIOLATION | Avoid unused private methods such as 'filterExistingDir'.


FILE: /shared/backups/forks/symbol-parser/src/Symbol/Loader/PsrSymbolLoader.php
-------------------------------------------------------------------------------
 22  | VIOLATION | Avoid unused local variables such as '$dir'.

Found 2 violations and 0 errors in 691ms
```

This PR fixed the two violations by upgrading code to compatible PHP 7.4 syntax !

### Goal 2

Remove unused imports

This PR add a PHP CS Fixer config file (`.php-cs-fixer.dist.php`) to detect at least unused imports

With such file content, and by running command 

```shell
php php-cs-fixer.phar check -v --diff
```

I got this report 

```text
PHP CS Fixer 3.35.1 (ec1ccc2) Freezy Vrooom by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.2.16
Loaded config default from "/shared/backups/forks/symbol-parser/.php-cs-fixer.dist.php".
..............................F.F..................................................................                               99 / 99 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error
   1) src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php (no_unused_imports)
      ---------- begin diff ----------
--- /shared/backups/forks/symbol-parser/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
+++ /shared/backups/forks/symbol-parser/src/Parser/PHP/Strategy/FullQualifiedParameterStrategy.php
@@ -5,7 +5,6 @@
 namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;

 use PhpParser\Node;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;

 final class FullQualifiedParameterStrategy implements StrategyInterface

      ----------- end diff -----------

   2) src/Parser/PHP/SymbolCollectorInterface.php (no_unused_imports)
      ---------- begin diff ----------
--- /shared/backups/forks/symbol-parser/src/Parser/PHP/SymbolCollectorInterface.php
+++ /shared/backups/forks/symbol-parser/src/Parser/PHP/SymbolCollectorInterface.php
@@ -5,7 +5,6 @@
 namespace ComposerUnused\SymbolParser\Parser\PHP;

 use Closure;
-use ComposerUnused\SymbolParser\Symbol\SymbolName;
 use PhpParser\NodeVisitor;

 interface SymbolCollectorInterface extends NodeVisitor

      ----------- end diff -----------


Found 2 of 99 files that can be fixed in 0.319 seconds, 18.633 MB memory used
```

