### PR TITLE
Global namespace imports

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRules([
+        'global_namespace_import' => ['import_classes' => true, 'import_constants' => true, 'import_functions' => true],
         'no_unused_imports' => true,
     ])
     ->setFinder(

--- a/src/Parser/PHP/Strategy/AnnotationStrategy.php
+++ b/src/Parser/PHP/Strategy/AnnotationStrategy.php
@@ -24,6 +24,8 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use RecursiveIteratorIterator;
+use RecursiveArrayIterator;
 
 final class AnnotationStrategy implements StrategyInterface
 {
@@ -156,7 +158,7 @@ final class AnnotationStrategy implements StrategyInterface
      */
     private function flattenArray(array $array): array
     {
-        $iterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($array));
+        $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
 
         return iterator_to_array($iterator, false);
     }

--- a/src/Symbol/Loader/FileSymbolLoader.php
+++ b/src/Symbol/Loader/FileSymbolLoader.php
@@ -11,10 +11,14 @@ use Symfony\Component\Finder\Finder;
 
 use function array_map;
 use function array_merge;
+use function defined;
 use function is_array;
 use function preg_match;
 
 use const DIRECTORY_SEPARATOR;
+use const GLOB_BRACE;
+use const GLOB_ONLYDIR;
+use const GLOB_NOSORT;
 
 final class FileSymbolLoader implements SymbolLoaderInterface
 {
@@ -142,7 +146,7 @@ final class FileSymbolLoader implements SymbolLoaderInterface
             return true;
         }
 
-        $glob = glob($dir, (\defined('GLOB_BRACE') ? \GLOB_BRACE : 0) | \GLOB_ONLYDIR | \GLOB_NOSORT);
+        $glob = glob($dir, (defined('GLOB_BRACE') ? GLOB_BRACE : 0) | GLOB_ONLYDIR | GLOB_NOSORT);
 
         return $glob !== [];
     }

--- a/tests/assets/TestFiles/PhpExtensionStrategy/ClassWithExtensionInterface.php
+++ b/tests/assets/TestFiles/PhpExtensionStrategy/ClassWithExtensionInterface.php
@@ -3,8 +3,9 @@
 declare(strict_types=1);
 
 namespace TestFile {
+use JsonSerializable;
 
-    class ClassWithExtensionInterface implements \JsonSerializable
+    class ClassWithExtensionInterface implements JsonSerializable
     {
         public function jsonSerialize()
         {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Goal 

Follows my [suggestion](https://github.com/composer-unused/symbol-parser/pull/125#issuecomment-1951370430)

Expected PHP CS Fixer ouput by running command : `php php-cs-fixer.phar fix --dry-run -v --using-cache=no`

```text
PHP CS Fixer 3.35.1 (ec1ccc2) Freezy Vrooom by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.2.16
Loaded config default from "/shared/backups/forks/symbol-parser/.php-cs-fixer.dist.php".
........F............F....................................................F........................                               99 / 99 (100%)
Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error
   1) src/Symbol/Loader/FileSymbolLoader.php (global_namespace_import)
   2) src/Parser/PHP/Strategy/AnnotationStrategy.php (global_namespace_import)
   3) tests/assets/TestFiles/PhpExtensionStrategy/ClassWithExtensionInterface.php (global_namespace_import)

Found 3 of 99 files that can be fixed in 0.459 seconds, 18.633 MB memory used
```
