### PR TITLE
Add typed properties when missing

### DIFF
--- a/src/Parser/PHP/ConsumedSymbolCollector.php
+++ b/src/Parser/PHP/ConsumedSymbolCollector.php
@@ -21,9 +21,9 @@ use function array_unique;
 class ConsumedSymbolCollector extends AbstractCollector
 {
     /** @var array<string> */
-    private $symbols = [];
+    private array $symbols = [];
     /** @var array<StrategyInterface> */
-    private $strategies;
+    private array $strategies;
 
     /**
      * @param array<StrategyInterface> $strategies

--- a/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
+++ b/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
@@ -11,17 +11,16 @@ use ReflectionFunction;
 final class PhpExtensionStrategy implements StrategyInterface
 {
     /** @var array<string, array<string, int>> */
-    private $extensionConstants = [];
+    private array $extensionConstants = [];
 
     /** @var array<string, array<ReflectionFunction>> */
-    private $extensionFunctions = [];
+    private array $extensionFunctions = [];
 
     /** @var array<string, array<string, int>> */
-    private $extensionClasses = [];
+    private array $extensionClasses = [];
 
     /**
      * @param array<string> $extensions
-     * @throws ReflectionException
      */
     public function __construct(array $extensions, LoggerInterface $logger)
     {

--- a/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
+++ b/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
@@ -13,17 +13,16 @@ use function array_key_exists;
 final class UsedExtensionSymbolStrategy implements StrategyInterface
 {
     /** @var array<string, array<string, int>> */
-    private $extensionConstants = [];
+    private array $extensionConstants = [];
 
     /** @var array<string, array<ReflectionFunction>> */
-    private $extensionFunctions = [];
+    private array $extensionFunctions = [];
 
     /** @var array<string, array<string, int>> */
-    private $extensionClasses = [];
+    private array $extensionClasses = [];
 
     /**
      * @param array<string> $extensions
-     * @throws ReflectionException
      */
     public function __construct(array $extensions, LoggerInterface $logger)
     {

--- a/src/Symbol/Loader/CompositeSymbolLoader.php
+++ b/src/Symbol/Loader/CompositeSymbolLoader.php
@@ -10,10 +10,10 @@ use Generator;
 final class CompositeSymbolLoader implements SymbolLoaderInterface
 {
     /** @var array<SymbolLoaderInterface> */
-    private $symbolLoader;
+    private array $symbolLoader;
 
     /** @var string|null */
-    private $baseDir;
+    private ?string $baseDir = null;
 
     /**
      * @param array<SymbolLoaderInterface> $symbolLoader

--- a/src/Symbol/NamespaceSymbol.php
+++ b/src/Symbol/NamespaceSymbol.php
@@ -6,8 +6,7 @@ namespace ComposerUnused\SymbolParser\Symbol;
 
 final class NamespaceSymbol implements SymbolInterface
 {
-    /** @var string */
-    private $namespace;
+    private string $namespace;
 
     public function __construct(string $namespace)
     {

--- a/src/Symbol/Provider/FileSymbolProvider.php
+++ b/src/Symbol/Provider/FileSymbolProvider.php
@@ -15,12 +15,9 @@ use Iterator;
 
 class FileSymbolProvider implements FileIterationInterface
 {
-    /** @var SymbolNameParserInterface */
-    private $parser;
-    /** @var FileContentProvider */
-    private $fileContentProvider;
-    /** @var AppendIterator */
-    private $fileIterator;
+    private SymbolNameParserInterface $parser;
+    private FileContentProvider $fileContentProvider;
+    private AppendIterator $fileIterator;
 
     public function __construct(SymbolNameParserInterface $parser, FileContentProvider $fileContentProvider)
     {

--- a/src/Symbol/SymbolList.php
+++ b/src/Symbol/SymbolList.php
@@ -12,7 +12,7 @@ use function iterator_to_array;
 final class SymbolList implements SymbolListInterface
 {
     /** @var array<SymbolInterface> */
-    private $items = [];
+    private array $items = [];
 
     /**
      * @param Traversable<SymbolInterface> $symbols


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Goal

As this package requires at least PHP 7.4, I think we could generalized, as much as possible, [Typed properties](https://wiki.php.net/rfc/typed_properties_v2) implementation.

This is the main goal of this PR.
