### PR TITLE
Code QA : add `declare_strict_types` if necessary and remove unused import

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRules([
+        'declare_strict_types' => true,
+        'linebreak_after_opening_tag' => true,
+        'blank_line_after_opening_tag' => true,
         'global_namespace_import' => ['import_classes' => true, 'import_constants' => true, 'import_functions' => true],
         'no_unused_imports' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude('vendor')
-            ->notPath('assets/TestFiles/UseSingleLineNoGroup.php')
+            ->notPath('assets/')
             ->in([__DIR__.'/src/', __DIR__.'/tests/'])
     )
 ;

--- a/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
+++ b/src/Parser/PHP/Strategy/PhpExtensionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;
 
 use PhpParser\Node;

--- a/src/Parser/PHP/Strategy/UseStrategy.php
+++ b/src/Parser/PHP/Strategy/UseStrategy.php
@@ -7,7 +7,6 @@ namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\Stmt\UseUse;
 
 class UseStrategy implements StrategyInterface
 {

--- a/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
+++ b/src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ComposerUnused\SymbolParser\Parser\PHP\Strategy;
 
 use PhpParser\Node;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Enhance code

Add new rules to PHP CS Fixer config file to ensure code follows CS defined by the project.

Run PHP CS Fixer on code base (commit 069121597b4bb4c9a2db97a5a046ddf664f9ec0a)

```shell
php php-cs-fixer.phar fix --dry-run -v --allow-risky=yes
```

```text
PHP CS Fixer 3.50.0 (8794475) Insomnia by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.16
Loaded config default from "/shared/backups/forks/symbol-parser/.php-cs-fixer.dist.php".
Using cache file ".php-cs-fixer.cache".
 60/60 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

   1) src/Parser/PHP/Strategy/UsedExtensionSymbolStrategy.php (declare_strict_types, blank_line_after_opening_tag)
   2) src/Parser/PHP/Strategy/UseStrategy.php (no_unused_imports)
   3) src/Parser/PHP/Strategy/PhpExtensionStrategy.php (declare_strict_types, blank_line_after_opening_tag)

Fixed 3 of 60 files in 0.263 seconds, 18.711 MB memory used
```
