### PR TITLE
Skip already visited files

### DIFF
--- a/src/Parser/PHP/AbstractCollector.php
+++ b/src/Parser/PHP/AbstractCollector.php
@@ -45,9 +45,11 @@ abstract class AbstractCollector extends NodeVisitorAbstract implements SymbolCo
             case Node\Expr\BinaryOp\Concat::class:
                 $fileInclude = FileInclude::fromConcatOperation($expr);
                 break;
+            default:
+                return;
         }
 
-        if (isset($fileInclude, self::$visited[$fileInclude->getPath()])) {
+        if (isset(self::$visited[$fileInclude->getPath()])) {
             return;
         }
         self::$visited[$fileInclude->getPath()] = true;

--- a/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
+++ b/tests/Integration/Symbol/Loader/FileSymbolLoaderTest.php
@@ -14,6 +14,7 @@ class FileSymbolLoaderTest extends AbstractIntegrationTestCase
     private const ARRAY_NAMESPACE = __DIR__ . '/../../../assets/TestProjects/ArrayNamespace';
     private const CLASSMAP_AUTOLOAD = __DIR__ . '/../../../assets/TestProjects/ClassmapAutoload';
     private const MISSING_DIRECTORY = __DIR__ . '/../../../assets/TestProjects/MissingDirectory';
+    private const SELF_REFERENCING = __DIR__ . '/../../../assets/TestProjects/SelfReferencing';
 
     /**
      * @test
@@ -80,6 +81,16 @@ class FileSymbolLoaderTest extends AbstractIntegrationTestCase
     public function itSkipsNonExistingDirectories(): void
     {
         $symbols = $this->loadDefinedFileSymbols(self::MISSING_DIRECTORY, [AutoloadType::PSR4]);
+
+        self::assertCount(0, $symbols);
+    }
+
+    /**
+     * @test
+     */
+    public function itSkipsSelfReferencingFiles(): void
+    {
+        $symbols = $this->loadDefinedFileSymbols(self::SELF_REFERENCING, [AutoloadType::FILES]);
 
         self::assertCount(0, $symbols);
     }

--- a/tests/Unit/Parser/PHP/SymbolNameParserTest.php
+++ b/tests/Unit/Parser/PHP/SymbolNameParserTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace ComposerUnused\SymbolParser\Test\Unit\Parser\PHP;
 
+use ComposerUnused\SymbolParser\Parser\PHP\DefinedSymbolCollector;
+use ComposerUnused\SymbolParser\Parser\PHP\NameResolver;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\ExtendsParseStrategy;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\ImplementsParseStrategy;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\UseStrategy;
+use ComposerUnused\SymbolParser\Parser\PHP\SymbolNameParser;
 use ComposerUnused\SymbolParser\Test\ParserTestCase;
+use PhpParser\ParserFactory;
 
 final class SymbolNameParserTest extends ParserTestCase
 {
@@ -148,5 +152,45 @@ final class SymbolNameParserTest extends ParserTestCase
         self::assertSame('ezcReflectionMethod', $symbols[1]);
         self::assertSame('ezcReflectionFunction', $symbols[2]);
         self::assertSame('Suit', $symbols[3]);
+    }
+
+
+    /**
+     * @test
+     * @link https://github.com/composer-unused/symbol-parser/issues/136
+     */
+    public function itSkipsAlreadyVisitedFiles(): void
+    {
+        /* @Given a symbol collector which follows includes. */
+        $includes = [];
+        $collector = new DefinedSymbolCollector();
+        $collector->setFileIncludeCallback(function ($file) use (&$includes) {
+            array_push($includes, $file->getPath());
+        });
+        $parser = new SymbolNameParser(
+            (new ParserFactory())->createForNewestSupportedVersion(),
+            new NameResolver(),
+            $collector
+        );
+
+        /* @When the source code includes the same file multiple times. */
+        $code = <<<CODE
+        <?php
+
+        include 'test1.php';
+        include 'test2.php';
+        include 'test3.php';
+        include 'test1.php'; // should get skipped
+        include 'test2.php'; // should get skipped
+        include 'test3.php'; // should get skipped
+        CODE;
+        iterator_to_array($parser->parseSymbolNames($code));
+
+        /* @And the symbol parser (+ collector) does multiple passes on the source code. */
+        iterator_to_array($parser->parseSymbolNames($code));
+
+        /* @Then the collector only followed each unique file once. */
+        self::assertCount(3, $includes);
+        self::assertEquals(['test1.php', 'test2.php', 'test3.php'], $includes);
     }
 }

--- a/tests/assets/TestProjects/SelfReferencing/composer.json
+++ b/tests/assets/TestProjects/SelfReferencing/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "self/referencing",
+
+    "autoload": {
+        "files": ["index.php"]
+    }
+}

--- a/tests/assets/TestProjects/SelfReferencing/index.php
+++ b/tests/assets/TestProjects/SelfReferencing/index.php
@@ -1,0 +1,3 @@
+<?php
+
+include 'index.php';


### PR DESCRIPTION
This PR attempts to fix the bugs reported in:
- composer-unused/composer-unused#659
- composer-unused/composer-unused#643
- composer-unused/composer-unused#612

A self-referencing file or a cyclic dependency would generate an infinite loop during parsing.

Code example:

```php
// test.php -- name of file must match the require_once path
<?php

require_once ('test.php');
```

The chosen solution is that the parser should keep track of files it has already visited and skip reparsing them.

---

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
