### PR TITLE
Add support for phpstan/phpdoc-parser v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "^7.4 || ^8.0",
         "composer-unused/contracts": "^0.3",
         "nikic/php-parser": "^4.18 || ^5.0",
-        "phpstan/phpdoc-parser": "^1.25",
+        "phpstan/phpdoc-parser": "^1.25 || ^2",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2 || ^3",
         "symfony/finder": "^5.3 || ^6.0 || ^7.0"

--- a/src/Parser/PHP/Strategy/AnnotationStrategy.php
+++ b/src/Parser/PHP/Strategy/AnnotationStrategy.php
@@ -24,6 +24,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 use RecursiveIteratorIterator;
 use RecursiveArrayIterator;
 
@@ -34,11 +35,19 @@ final class AnnotationStrategy implements StrategyInterface
 
     public function __construct(
         ConstExprParser $constExprParser,
-        Lexer $lexer
+        Lexer $lexer,
+        ParserConfig $parserConfig = null
     ) {
         $this->lexer = $lexer;
-        $typeParser = new TypeParser($constExprParser);
-        $this->phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+        if ($parserConfig !== null) {
+            $typeParser = new TypeParser($parserConfig, $constExprParser);
+            $this->phpDocParser = new PhpDocParser($parserConfig, $typeParser, $constExprParser);
+        } else {
+            // @phpstan-ignore-next-line
+            $typeParser = new TypeParser($constExprParser);
+            // @phpstan-ignore-next-line
+            $this->phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+        }
     }
 
     public function canHandle(Node $node): bool

--- a/tests/Unit/Parser/PHP/Strategy/AnnotationStrategyTest.php
+++ b/tests/Unit/Parser/PHP/Strategy/AnnotationStrategyTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace ComposerUnused\SymbolParser\Test\Unit\Parser\PHP\Strategy;
 
+use Composer\InstalledVersions;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\AnnotationStrategy;
 use ComposerUnused\SymbolParser\Test\ParserTestCase;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\ParserConfig;
 
 final class AnnotationStrategyTest extends ParserTestCase
 {
@@ -15,9 +17,25 @@ final class AnnotationStrategyTest extends ParserTestCase
 
     protected function setUp(): void
     {
+        $phpStanPhpDocParserVersion = InstalledVersions::getVersion('phpstan/phpdoc-parser');
+        if (!is_string($phpStanPhpDocParserVersion)) {
+            throw new \RuntimeException('Unable to get phpstan/phpdoc-parser version');
+        }
+        $phpStanPhpDocParserV2 = substr($phpStanPhpDocParserVersion, 0, 1) === '2';
+        $arguments = [];
+        if ($phpStanPhpDocParserV2) {
+            $parserConfig = new ParserConfig(['lines' => true, 'indexes' => true, 'comments' => true]);
+            $arguments[] = new ConstExprParser($parserConfig);
+            $arguments[] = new Lexer($parserConfig);
+            $arguments[] = $parserConfig;
+        } else {
+            // @phpstan-ignore-next-line
+            $arguments[] = new ConstExprParser();
+            // @phpstan-ignore-next-line
+            $arguments[] = new Lexer();
+        }
         $this->strategy = new AnnotationStrategy(
-            new ConstExprParser(),
-            new Lexer()
+            ...$arguments,
         );
     }
 


### PR DESCRIPTION
This PR depends on #180 for maximum certainty, it addresses https://github.com/composer-unused/composer-unused/issues/669 and https://github.com/composer-unused/composer-unused/discussions/667 by supporting phpstan/phpdoc-parser v1 and v2. Be it with some hacky changes.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
