### PR TITLE
fix: ClassConstStrategy should return the class symbol

### DIFF
--- a/src/Parser/PHP/Strategy/ClassConstStrategy.php
+++ b/src/Parser/PHP/Strategy/ClassConstStrategy.php
@@ -21,10 +21,6 @@ final class ClassConstStrategy implements StrategyInterface
             return false;
         }
 
-        if (!$node->name instanceof Node\Identifier) {
-            return false;
-        }
-
         return true;
     }
 
@@ -34,6 +30,9 @@ final class ClassConstStrategy implements StrategyInterface
      */
     public function extractSymbolNames(Node $node): array
     {
-        return [sprintf('%s\%s', $node->class, $node->name)];
+        /** @var Node\Name $class */
+        $class = $node->class;
+
+        return [$class->name];
     }
 }

--- a/tests/Unit/Parser/PHP/Strategy/ClassConstStrategyTest.php
+++ b/tests/Unit/Parser/PHP/Strategy/ClassConstStrategyTest.php
@@ -63,8 +63,8 @@ class ClassConstStrategyTest extends ParserTestCase
         $symbols = $this->parseConsumedSymbols([$this->strategy], $code);
 
         self::assertCount(3, $symbols);
-        self::assertSame('My\Space\Base\BAR', $symbols[0]);
-        self::assertSame('static\BAR', $symbols[1]);
-        self::assertSame('My\Space\Foo\BAR', $symbols[2]);
+        self::assertSame('My\Space\Base', $symbols[0]);
+        self::assertSame('static', $symbols[1]);
+        self::assertSame('My\Space\Foo', $symbols[2]);
     }
 }


### PR DESCRIPTION
The ClassConstStrategy needs to return the actual class instead of the full const name including the class. As this is the actual class being used.