### PR TITLE
fix: Add fallback resolution for parts or name

### DIFF
--- a/src/Parser/PHP/NameContext.php
+++ b/src/Parser/PHP/NameContext.php
@@ -17,8 +17,13 @@ class NameContext extends \PhpParser\NameContext
     public function getResolvedName(Name $name, int $type): ?Name
     {
         if ($type === Stmt\Use_::TYPE_NORMAL && $name->isSpecialClassName()) {
-            // Try to resolve aliases
-            return $this->aliases[$type][strtolower($name->name)] ?? null;
+            if (property_exists($name, 'name')) {
+                $className = $name->name;
+            } else {
+                $className = $name->getParts()[0];
+            }
+
+            return $this->aliases[$type][strtolower($className)] ?? null;
         }
         return parent::getResolvedName($name, $type);
     }

--- a/src/Parser/PHP/Strategy/ClassConstStrategy.php
+++ b/src/Parser/PHP/Strategy/ClassConstStrategy.php
@@ -33,6 +33,10 @@ final class ClassConstStrategy implements StrategyInterface
         /** @var Node\Name $class */
         $class = $node->class;
 
-        return [$class->name];
+        if (property_exists($class, 'name') === true) {
+            return [$class->name];
+        }
+
+        return [implode('\\', $class->getParts())];
     }
 }


### PR DESCRIPTION
php-parser in v5 introduced the `name` property.
In v4 there was only `getParts`. This solves an undefined property issue when using php-parser v4