### PR TITLE
Auto detect PHP version matrix

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
 
 jobs:
+  supported-versions-matrix:
+    name: Supported Versions Matrix
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    outputs:
+      version: ${{ steps.supported-versions-matrix.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: supported-versions-matrix
+        uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
+
   coding-standard:
     name: "Coding Standard"
     runs-on: "${{ matrix.os }}"
@@ -34,11 +44,13 @@ jobs:
   static-analysis:
     name: "Static Analysis"
     runs-on: "${{ matrix.os }}"
+    needs: supported-versions-matrix
     strategy:
       fail-fast: true
       matrix:
-        php: [ "8.1", "8.2", "8.3", "8.4" ]
+        php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
         os: [ "blacksmith-4vcpu-ubuntu-2204" ]
+        exclude: [ { php: "7.4" } ]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,10 +72,11 @@ jobs:
     name: "Unit Tests"
     runs-on: "${{ matrix.os }}"
     continue-on-error: "${{ matrix.experimental }}"
+    needs: supported-versions-matrix
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.1", "8.2", "8.3", "8.4" ]
+        php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
         os: [ "blacksmith-4vcpu-ubuntu-2204" ]
         experimental: [ false ]
 


### PR DESCRIPTION
Not trying to plug my own action here, but since I've done this for 8.4 and 8.3 in https://github.com/composer-unused/symbol-parser/pull/180 maybe this is an easier to maintain set up.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?
