### PR TITLE
fix: Avoid returning from symbolLoader

### DIFF
--- a/src/Symbol/Loader/FileSymbolLoader.php
+++ b/src/Symbol/Loader/FileSymbolLoader.php
@@ -57,22 +57,21 @@ final class FileSymbolLoader implements SymbolLoaderInterface
 
         $sourceFolders = array_filter($sourceFolders, fn (string $dir): bool => $this->filterExistingDir($dir));
 
-        $finder = new Finder();
-        if (empty($sourceFolders) && empty($sourceFiles)) {
-            return;
-        }
-        $files = $finder
-            ->files()
-            ->name('*.php')
-            ->in($sourceFolders)
-            ->append($sourceFiles)
-            ->ignoreDotFiles(true)
-            ->ignoreVCS(true)
-            ->ignoreUnreadableDirs()
-            ->followLinks()
-            ->exclude($this->excludedDirs);
+        if (!(empty($sourceFolders) && empty($sourceFiles))) {
+            $finder = new Finder();
+            $files = $finder
+                ->files()
+                ->in($sourceFolders)
+                ->append($sourceFiles)
+                ->name('*.php')
+                ->ignoreDotFiles(true)
+                ->ignoreVCS(true)
+                ->ignoreUnreadableDirs()
+                ->followLinks()
+                ->exclude($this->excludedDirs);
 
-        $this->fileSymbolProvider->appendFiles($files->getIterator());
+            $this->fileSymbolProvider->appendFiles($files->getIterator());
+        }
 
         yield from $this->fileSymbolProvider->provide();
     }


### PR DESCRIPTION
Returning from symbol loader stops the whole iteration.

We need to only find additional files if the have them otherwise still yield from the symbolProvider.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/symbol-parser/blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/composer-unused/symbol-parser/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
